### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,6 @@ Nuxt Disqus provides a wrapper for [vue3-disqus](https://github.com/modbender/vu
 1. Add `nuxt-disqus` dependency to your project
 
    ```bash
-   # Using pnpm
-   npx nuxi@latest module add disqus
-
-   # Using yarn
-   npx nuxi@latest module add disqus
-
-   # Using npm
    npx nuxi@latest module add disqus
    ```
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Nuxt Disqus provides a wrapper for [vue3-disqus](https://github.com/modbender/vu
 
    ```bash
    # Using pnpm
-   pnpm add -D nuxt-disqus
+   npx nuxi@latest module add disqus
 
    # Using yarn
-   yarn add --dev nuxt-disqus
+   npx nuxi@latest module add disqus
 
    # Using npm
-   npm install --save-dev nuxt-disqus
+   npx nuxi@latest module add disqus
    ```
 
 2. Add `nuxt-disqus` to the `modules` section of `nuxt.config.ts`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
